### PR TITLE
bumping wordpress compatibility to 5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:5.3.2-php7.2-apache
+FROM wordpress:5.4.0-php7.2-apache
 
 RUN apt-get update && \
 	apt-get install -y  --no-install-recommends ssl-cert && \

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: odathp, radius314, pjaudiomv, californiasteve9390, Paul N
 Tags: na, meeting list, meeting finder, maps, recovery, addiction, webservant, bmlt
 Requires at least: 4.0
 Required PHP: 5.6
-Tested up to: 5.3.2
+Tested up to: 5.4.0
 Stable tag: 3.9.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
I bumped all bmlt readmes in svn to 5.4 https://wordpress.org/plugins/search/bmlt/ this just updates repo