### PR TITLE
change meeting-additional-info css to work better with darker themes

### DIFF
--- a/crouton.php
+++ b/crouton.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/plugins/crouton/
 Description: A tabbed based display for showing meeting information.
 Author: bmlt-enabled
 Author URI: https://bmlt.app
-Version: 3.11.4
+Version: 3.11.5
 */
 /* Disallow direct access to the plugin file */
 if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {

--- a/croutonjs/src/css/bmlt_tabs.css
+++ b/croutonjs/src/css/bmlt_tabs.css
@@ -607,7 +607,6 @@ table.tablesaw {
 }
 
 .meeting-additional-info {
-	font-weight: 700;
+	font-weight: bold;
 	font-size: 14px;
-	color: rgba(0,0,0,0.67);
 }

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,9 @@ https://demo.bmlt.app/crouton
 
 == Changelog ==
 
+= 3.11.5 =
+* Changed meeting-additional-info css to work better with darker themes.
+
 = 3.11.4 =
 * New theme asheboro to match root server aesthetic.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: na, meeting list, meeting finder, maps, recovery, addiction, webservant, b
 Requires at least: 4.0
 Required PHP: 5.6
 Tested up to: 5.4.1
-Stable tag: 3.11.4
+Stable tag: 3.11.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 crouton implements a Tabbed UI for BMLT.


### PR DESCRIPTION
The css for meeting-additional-info worked well with themes like jack but not darker ones like florida-nights. This changes it to be something reasonable for all of the themes.