### PR TITLE
fix service_body_names shortcode by using promise

### DIFF
--- a/crouton.php
+++ b/crouton.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/plugins/crouton/
 Description: A tabbed based display for showing meeting information.
 Author: bmlt-enabled
 Author URI: https://bmlt.app
-Version: 3.12.6
+Version: 3.12.7
 */
 /* Disallow direct access to the plugin file */
 if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {

--- a/croutonjs/src/js/crouton-core.js
+++ b/croutonjs/src/js/crouton-core.js
@@ -707,7 +707,7 @@ Crouton.prototype.serviceBodyNames = function(callback) {
 	var self = this;
 	self.lock(function() {
 		var ids = getUniqueValuesOfKey(self.meetingData, 'service_body_bigint');
-		self.getServiceBodies(ids, function (service_bodies) {
+		self.getServiceBodies(ids).then(function (service_bodies) {
 			var n = service_bodies.length;
 			var names = [];
 			for (var i = 0; i < n; i++) {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: na, meeting list, meeting finder, maps, recovery, addiction, webservant, b
 Requires at least: 4.0
 Required PHP: 5.6
 Tested up to: 5.8.1
-Stable tag: 3.12.6
+Stable tag: 3.12.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 crouton implements a Tabbed UI for BMLT.
@@ -35,6 +35,9 @@ Crouton was forked from BMLT Tabbed UI plugin in 2018.  This plugin provides a T
 https://demo.bmlt.app/crouton
 
 == Changelog ==
+
+= 3.12.7 =
+* Fixed an issue with the [service_body_names] shortcode that was introduced in 3.12.6.
 
 = 3.12.6 =
 * Added capability to include parent service body details in templates (requires either Tomato or Root Server version 2.16.4 or greater).


### PR DESCRIPTION
When we switched to fetchJsonp and the promises polyfill, we forgot to rework this function's callback as a promise chain. Oops!

Fixes https://github.com/bmlt-enabled/crouton/issues/367