### PR TITLE
use mariadb 10.11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,10 @@ services:
       - ./logs/:/var/log/apache2
 
   db:
-    image: mysql:5.7
+    image: mariadb:10.11
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: somewordpress
-      MYSQL_DATABASE: wordpress
-      MYSQL_USER: wordpress
-      MYSQL_PASSWORD: wordpress
+      MARIADB_ROOT_PASSWORD: somewordpress
+      MARIADB_DATABASE: wordpress
+      MARIADB_USER: wordpress
+      MARIADB_PASSWORD: wordpress


### PR DESCRIPTION
the mysql 5.7 image doesn't support arm processors, ran into this trying to do docker-compose up on my m1. switching to mariadb 10.11 which is latest LTS