### PR TITLE
Include transition.js for popups and #314

### DIFF
--- a/croutonjs/src/js/transition.js
+++ b/croutonjs/src/js/transition.js
@@ -1,0 +1,59 @@
+/* ========================================================================
+ * Bootstrap: transition.js v3.3.7
+ * http://getbootstrap.com/javascript/#transitions
+ * ========================================================================
+ * Copyright 2011-2016 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * ======================================================================== */
+
+
++function ($) {
+  'use strict';
+
+  // CSS TRANSITION SUPPORT (Shoutout: http://www.modernizr.com/)
+  // ============================================================
+
+  function transitionEnd() {
+    var el = document.createElement('bootstrap')
+
+    var transEndEventNames = {
+      WebkitTransition : 'webkitTransitionEnd',
+      MozTransition    : 'transitionend',
+      OTransition      : 'oTransitionEnd otransitionend',
+      transition       : 'transitionend'
+    }
+
+    for (var name in transEndEventNames) {
+      if (el.style[name] !== undefined) {
+        return { end: transEndEventNames[name] }
+      }
+    }
+
+    return false // explicit for ie8 (  ._.)
+  }
+
+  // http://blog.alexmaccaw.com/css-transitions
+  $.fn.emulateTransitionEnd = function (duration) {
+    var called = false
+    var $el = this
+    $(this).one('bsTransitionEnd', function () { called = true })
+    var callback = function () { if (!called) $($el).trigger($.support.transition.end) }
+    setTimeout(callback, duration)
+    return this
+  }
+
+  $(function () {
+    $.support.transition = transitionEnd()
+
+    if (!$.support.transition) return
+
+    $.event.special.bsTransitionEnd = {
+      bindType: $.support.transition.end,
+      delegateType: $.support.transition.end,
+      handle: function (e) {
+        if ($(e.target).is(this)) return e.handleObj.handler.apply(this, arguments)
+      }
+    }
+  })
+
+}(jQuery);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ const notify = require('gulp-notify');
 
 let jsFilesNoJQuery = [
 	'bootstrap.min.js',
+	'transition.js',
 	'select2.full.min.js',
 	'tablesaw.jquery.3.0.9.js',
 	'handlebars-v4.5.3.js',

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,7 @@ https://demo.bmlt.app/crouton
 
 = 3.16.1 =
 * Fix problem with zebra-striping of filtered views.
+* Fix some problems with Bootstrap by including transition.js
 
 = 3.16.0 =
 * New shortcode [bmlt_handlebar]:  the contents of the shortcode are interpreted as a handlebarjs template.


### PR DESCRIPTION
Still need to get a handle of conflicts between our bootstrap (v3) and whatever version other plugins are loading and similar problems, but that is a larger project, and I would like to release 3.16.1 with just this fix.