### PR TITLE
remove services from query string for extra meetings query

### DIFF
--- a/croutonjs/src/js/crouton-core.js
+++ b/croutonjs/src/js/crouton-core.js
@@ -187,6 +187,8 @@ function Crouton(config) {
 			for (var i = 0; i < self.config['extra_meetings'].length; i++) {
 				extra_meetings_query += "&meeting_ids[]=" + self.config["extra_meetings"][i];
 			}
+			const regex = /&services\[\]=\d+/;
+			url = url.replace(regex, '');
 			promises.push(fetchJsonp(self.config['root_server'] + url + extra_meetings_query).then(function (response) { return response.json(); }));
 		}
 


### PR DESCRIPTION
Address #432 

Uses a regex to remove the `services[]=` param from the query string for extra meetings