### PR TITLE
rm unused admin notices

### DIFF
--- a/crouton.php
+++ b/crouton.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/plugins/crouton/
 Description: A tabbed based display for showing meeting information.
 Author: bmlt-enabled
 Author URI: https://bmlt.app
-Version: 3.17.7
+Version: 3.17.6
 */
 /* Disallow direct access to the plugin file */
 if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {

--- a/crouton.php
+++ b/crouton.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/plugins/crouton/
 Description: A tabbed based display for showing meeting information.
 Author: bmlt-enabled
 Author URI: https://bmlt.app
-Version: 3.17.6
+Version: 3.17.7
 */
 /* Disallow direct access to the plugin file */
 if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {
@@ -125,7 +125,6 @@ if (!class_exists("Crouton")) {
             $this->getOptions();
             if (is_admin()) {
                 // Back end
-                add_action("admin_notices", array(&$this, "isRootServerMissing"));
                 add_action("admin_enqueue_scripts", array(&$this, "enqueueBackendFiles"), 500);
                 add_action("admin_menu", array(&$this, "adminMenuLink"));
             } else {
@@ -202,21 +201,6 @@ if (!class_exists("Crouton")) {
             return true;
         }
 
-        public function isRootServerMissing()
-        {
-            add_action("admin_notices", array(
-                &$this,
-                "clearAdminMessage"
-            ));
-        }
-
-        private function clearAdminMessage()
-        {
-            remove_action("admin_notices", array(
-                &$this,
-                "isRootServerMissing"
-            ));
-        }
         // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         public function Crouton()
         {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: na, meeting list, meeting finder, maps, recovery, addiction, webservant, b
 Requires at least: 4.0
 Required PHP: 5.6
 Tested up to: 6.2.2
-Stable tag: 3.17.7
+Stable tag: 3.17.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 crouton implements a Tabbed UI for BMLT.
@@ -36,11 +36,9 @@ https://demo.bmlt.app/crouton
 
 == Changelog ==
 
-= 3.17.7 =
-* Remove unused admin notice which could cause problems on certain sites.
-
 = 3.17.6 =
 * Bug fix release - better parsing of <bmlt-handlebar> tags.
+* Remove unused admin notice which could cause problems on certain sites.
 
 = 3.17.5 =
 * hide meeting-details map if google maps but no api key

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: na, meeting list, meeting finder, maps, recovery, addiction, webservant, b
 Requires at least: 4.0
 Required PHP: 5.6
 Tested up to: 6.2.2
-Stable tag: 3.17.6
+Stable tag: 3.17.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 crouton implements a Tabbed UI for BMLT.
@@ -35,6 +35,9 @@ Crouton was forked from BMLT Tabbed UI plugin in 2018.  This plugin provides a T
 https://demo.bmlt.app/crouton
 
 == Changelog ==
+
+= 3.17.7 =
+* Remove unused admin notice which could cause problems on certain sites.
 
 = 3.17.6 =
 * Bug fix release - better parsing of <bmlt-handlebar> tags.


### PR DESCRIPTION
between the last 3.16 and somewhere in 3.17 the visibility was changed on `clearAdminMessage` method, which is causing issue on some sites. However the actual displaying of any message was removed in `3.9.0` (this commit https://github.com/bmlt-enabled/crouton/commit/0dd93a1af1da1c79f1d90b2abdc23ff96cd7242f). basically code rot