### PR TITLE
store/retireve coords from global var

### DIFF
--- a/crouton.php
+++ b/crouton.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/plugins/crouton/
 Description: A tabbed based display for showing meeting information.
 Author: bmlt-enabled
 Author URI: https://bmlt.app
-Version: 3.19.1
+Version: 3.19.2
 */
 /* Disallow direct access to the plugin file */
 if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {

--- a/croutonjs/meetingMap/css/meeting_map.css
+++ b/croutonjs/meetingMap/css/meeting_map.css
@@ -272,6 +272,9 @@ div.bmlt_map_container_div  button {
   float: right;
   font-size: 28px;
   font-weight: bold;
+  position: absolute;
+  top: 10px;
+  right: 5px;
   line-height: 0;
 }
 .table-close {
@@ -284,6 +287,16 @@ div.bmlt_map_container_div  button {
   color: white;
   font-weight:bold;
   font-size: 20px;
+}
+.modal-search {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+.modal-search .filter-button {
+  width: 100%
+}
+#goto-button {
+  margin-top: 10px;
 }
 .modal-close:hover,
 .modal-close:focus {

--- a/croutonjs/src/templates/mapMenu.hbs
+++ b/croutonjs/src/templates/mapMenu.hbs
@@ -42,9 +42,7 @@
         <div class="modal-search">
             {{getWord 'Enter a city or zip code'}}
             <input id="goto-text" type="text">
-            <p>
-                <button id="goto-button" class="filter-button">Los</button>
-            </p>
+            <button id="goto-button" class="filter-button">Los</button>
         </div>
   	</div>	
 </div>

--- a/croutonjs/src/templates/mapSearch.hbs
+++ b/croutonjs/src/templates/mapSearch.hbs
@@ -3,21 +3,18 @@
 </button>
 <div id="bmltsearch_modal" class="modal" style="display: none;">
 	<div id="bmltsearch_content" class="modal-content">
-		<span class="modal-title">{{getWord 'Search for meetings'}}</span><span id="close_search" class="modal-close">x</span>
+		<span id="close_search" class="modal-close">x</span>
+        <span class="modal-title">{{getWord 'Search for meetings'}}</span>
         <table>
         <tr><td><div class="modal-search">
             <input id="bmltsearch-goto-text" type="text" placeholder="{{getWord 'Enter a city or zip code'}}" style="margin-bottom:5px;">
             <button id="bmltsearch-text-button" class="filter-button">{{getWord 'text_search'}}</button>
         </div></td></tr>
         <tr><td><div class="modal-search">
-            <p>
                 <button id="bmltsearch-nearbyMeetings" class="filter-button">{{getWord 'near_me'}}</button>
-            </p>
         </div></td></tr>
         <tr><td><div class="modal-search">
-            <p>
                 <button id="bmltsearch-clicksearch" class="filter-button">{{getWord 'click_search'}}</button>
-            </p>
         </div></td></tr></table>
   	</div>	
 </div>

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: na, meeting list, meeting finder, maps, recovery, addiction, webservant, b
 Requires at least: 4.0
 Required PHP: 8.0
 Tested up to: 6.4.2
-Stable tag: 3.19.1
+Stable tag: 3.19.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 crouton implements a Tabbed UI for BMLT.
@@ -35,6 +35,9 @@ Crouton was forked from BMLT Tabbed UI plugin in 2018.  This plugin provides a T
 https://demo.bmlt.app/crouton
 
 == Changelog ==
+
+= 3.19.2 =
+* Only ask for user's location one time
 
 = 3.19.1 =
 * Fix compatibility issue with Elementor.


### PR DESCRIPTION
im sure there is better way to do this but example solution to https://github.com/bmlt-enabled/crouton/issues/480. this stores the location in `window.storedGeolocation` if it doesnt exist it prompts for it from `navigator.geolocation.getCurrentPosition` then stores in `window.storedGeolocation`